### PR TITLE
Prompt the user for a value for the category, if none was given

### DIFF
--- a/datreant_cli/cli.py
+++ b/datreant_cli/cli.py
@@ -100,8 +100,15 @@ def update(tags, categories, folder):
     if tags is not None:
         treant.tags = set(tags)
     if categories is not None:
-        for key, value in (c.split(":") for c in categories):
-            treant.categories[key] = value
+        try:
+            # Try if we got the expected `key:value` pair from the user.
+            for key, value in (c.split(":") for c in categories):
+                treant.categories[key] = value
+        except ValueError:
+            # The user provided us only with a key, but no value. Prompt them for a value.
+            for category in categories:
+                value = click.prompt("Please specify a value for {category}".format(category=category))
+                treant.categories[category] = value
 
 
 @cli.command()


### PR DESCRIPTION
We can now do a) `dtr update --category CATEGORY1:VALUE1 CATEGORY2:VALUE2` and b) `dtr update --category CATEGORY1 CATEGORY2`. In the first case, the values for both keys `CATEGORY1` and `CATEGORY2` are updated immediately. In the second case, the user is prompted for values first.

Resolves #6.